### PR TITLE
Add parse-csv-string-rows for multi-line csv rows

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,5 +20,8 @@ It was ported to Emacs Lisp by Matt Curtis.
     => ("a" "b" "c;d")
 
 (parse-csv-string-rows "a,b,c,do\"\ng\"\ne,f,g,h" ?\, ?\" "\n")
-    => (("a" "b" "c" "dog") ("e" "f" "g" "h"))
+    => (("a" "b" "c" "do\ng") ("e" "f" "g" "h"))
+
+(parse-csv-string-rows "a,b,c,do\"\ng\"\n\ne,f,g,h" ?\, ?\" "\n")
+    => (("a" "b" "c" "do\ng") ("") ("e" "f" "g" "h"))
 #+END_SRC

--- a/parse-csv.el
+++ b/parse-csv.el
@@ -93,6 +93,7 @@ string quoting character, and LINE-SEP as the line separator."
               (if rawlines; have more lines
                   (progn
                     (setq offset 0)
+                    (setq current-word (concat current-word line-sep))
                     (setq line (pop rawlines)))
                 (error "Unterminated string")))
              (:read-word
@@ -106,6 +107,18 @@ string quoting character, and LINE-SEP as the line separator."
                     (setq line (pop rawlines)))
                 (throw 'return
                        (nreverse lines))))))
+         ;; handle empty line
+         (if (= 0 (length line))
+             (cl-ecase state
+               (:in-string
+                (setq offset 0)
+                (setq current-word (concat current-word line-sep))
+                (setq line (pop rawlines)))
+               (:read-word
+                ;; new line!
+                (push (nreverse (cons current-word items)) lines)
+                (setq offset 0)
+                (setq line (pop rawlines))))
          (let ((current (aref line offset)))
            (cond
             ((char-equal separator current)
@@ -129,7 +142,7 @@ string quoting character, and LINE-SEP as the line separator."
                 (setq state :in-string))))
             (t
              (setq current-word (concat current-word (char-to-string current))))))
-         (incf offset))))))
+         (incf offset)))))))
 
 (provide 'parse-csv)
 

--- a/test-parse-csv.el
+++ b/test-parse-csv.el
@@ -43,6 +43,17 @@ monkies,rabbits,cherries" ?\, ?\" "
 
 (ert-deftest parse-csv-string-rows/two-simple-lines-correctly ()
   "Should parse two rows correctly"
-  (should (equal (length (parse-csv-string-rows "apples,bananas,carrots
-monkies,rabbits,cherries" ?\, ?\" "
-")))))
+  (should (equal (parse-csv-string-rows "apples,bananas,carrots\nmonkies,rabbits,cherries" ?\, ?\" "\n")
+                 '(("apples" "bananas" "carrots") ("monkies" "rabbits" "cherries")))))
+
+(ert-deftest parse-csv-string-rows/three-simple-lines-with-empy-line-correctly ()
+  "Should parse three lines with a blank middle row correctly"
+  (should (equal (parse-csv-string-rows "apples,bananas,carrots\n\nmonkies,rabbits,cherries" ?\, ?\" "\n")
+                 '(("apples" "bananas" "carrots") ("") ("monkies" "rabbits" "cherries")))))
+
+(ert-deftest parse-csv-string-rows/three-simple-lines-with-empy-line-correctly ()
+  "Should parse two lines with a multiline row correctly"
+  (should
+   (equal
+    (parse-csv-string-rows "apples,bananas,\"carrots\nare delicious\"\nmonkies,rabbits,cherries" ?\, ?\" "\n")
+    '(("apples" "bananas" "carrots\nare delicious") ("monkies" "rabbits" "cherries")))))


### PR DESCRIPTION
Wanted to support multi-line entries.
