### PR TITLE
Use cl-lib macros instead of cl.el

### DIFF
--- a/parse-csv.el
+++ b/parse-csv.el
@@ -85,7 +85,7 @@ string quoting character, and LINE-SEP as the line separator."
     (catch 'return
       (progn
         (setq line (pop rawlines))
-        (loop
+        (cl-loop
          (when (or (not line) (= offset (length line)))
            ;; all done
            (cl-ecase state
@@ -136,13 +136,13 @@ string quoting character, and LINE-SEP as the line separator."
                    ((and (/= offset+1 (length line))
                          (char-equal quote-char (aref line offset+1)))
                     (setq current-word (concat current-word (char-to-string quote-char)))
-                    (incf offset))
+                    (cl-incf offset))
                    (t (setq state :read-word)))))
                (:read-word
                 (setq state :in-string))))
             (t
              (setq current-word (concat current-word (char-to-string current))))))
-         (incf offset)))))))
+         (cl-incf offset)))))))
 
 (provide 'parse-csv)
 


### PR DESCRIPTION
This package loads cl-lib, but it uses some cl.el macros. This causes following byte-compile warning.

```
In end of data:                                                                        
parse-csv.el:154:1:Warning: the following functions are not known to be                
    defined: loop, incf
```
